### PR TITLE
Support multi-provider cloning and private repo authentication

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -94,6 +94,7 @@ dependencies = [
  "tree-sitter",
  "tree-sitter-javascript",
  "tree-sitter-python",
+ "url",
  "walkdir",
 ]
 

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2024"
 
 [dependencies]
 git2 = "0.20.4"
+url = "2"
 walkdir = "2.4"
 tree-sitter = "0.22"
 tree-sitter-python = "0.21"

--- a/backend/src/errors.rs
+++ b/backend/src/errors.rs
@@ -13,6 +13,7 @@ struct ErrorResponse {
 pub enum AppError {
     NotFound(String),
     AlreadyExists(String),
+    InvalidInput(String),
     GitError(String),
     ParseError(String),
     InternalError(String),
@@ -23,6 +24,7 @@ impl IntoResponse for AppError {
         let (status, message) = match self {
             AppError::NotFound(msg) => (StatusCode::NOT_FOUND, msg),
             AppError::AlreadyExists(msg) => (StatusCode::CONFLICT, msg),
+            AppError::InvalidInput(msg) => (StatusCode::BAD_REQUEST, msg),
             AppError::GitError(msg) | AppError::InternalError(msg) => (StatusCode::INTERNAL_SERVER_ERROR, msg),
             AppError::ParseError(msg) => (StatusCode::UNPROCESSABLE_ENTITY, msg),
         };
@@ -34,6 +36,17 @@ impl IntoResponse for AppError {
 
 impl From<git2::Error> for AppError {
     fn from(err: git2::Error) -> Self {
+        let is_auth_error = err.code() == git2::ErrorCode::Auth
+            || (err.class() == git2::ErrorClass::Http
+            && err.message().contains("401"));
+
+        if is_auth_error {
+            return AppError::InvalidInput(
+                "Authentication failed, the repository may be private. Try providing a token."
+                    .to_string(),
+            );
+        }
+
         AppError::GitError(format!("Git error: {err}"))
     }
 }

--- a/backend/src/handlers.rs
+++ b/backend/src/handlers.rs
@@ -21,16 +21,26 @@ pub async fn clone_handler(
     State(config): State<Arc<AppConfig>>,
     Json(payload): Json<CloneRequest>,
 ) -> Result<impl IntoResponse, AppError> {
+    repo::validate_repo_url(&payload.url)?;
+
     let url = payload.url;
+    let token = payload.token;
     let target_path = config.base_dir.join(&payload.name);
 
     if target_path.exists() {
         return Err(AppError::AlreadyExists("Directory already exists".to_string()));
     }
 
+    let token_clone = token.clone();
+    let target_clone = target_path.clone();
+
     tokio::task::spawn_blocking(move || {
-        repo::clone_repo(&url, target_path)
+        repo::clone_repo(&url, target_clone, token_clone.as_deref())
     }).await??;
+
+    if let Some(ref token) = token {
+        repo::save_token(&target_path, token)?;
+    }
 
     Ok(Json("Repository cloned successfully"))
 }

--- a/backend/src/models.rs
+++ b/backend/src/models.rs
@@ -11,6 +11,7 @@ pub struct RepoInfo {
 pub struct CloneRequest {
     pub url: String,
     pub name: String,
+    pub token: Option<String>,
 }
 
 #[derive(Serialize)]

--- a/backend/src/repo.rs
+++ b/backend/src/repo.rs
@@ -1,11 +1,41 @@
 use std::fs;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use walkdir::WalkDir;
 use git2::Repository;
 
 use crate::errors::AppError;
 use crate::models::{RepoInfo, ParsedRepo};
 use crate::parsers::get_parser_for_extension;
+
+const TOKEN_FILE: &str = ".dockix-token";
+
+pub fn validate_repo_url(url: &str) -> Result<(), AppError> {
+    if !url.starts_with("https://") && !url.starts_with("http://") {
+        return Err(AppError::InvalidInput(
+            "URL must use https:// or http://".to_string(),
+        ));
+    }
+
+    let after_scheme = url.split("://").nth(1).unwrap_or("");
+    let parts: Vec<&str> = after_scheme.splitn(2, '/').collect();
+
+    if parts.len() < 2 || parts[0].is_empty() || parts[1].is_empty() {
+        return Err(AppError::InvalidInput(
+            "URL must include a host and path (e.g. https://github.com/user/repo)".to_string(),
+        ));
+    }
+
+    Ok(())
+}
+
+pub fn save_token(repo_path: &Path, token: &str) -> Result<(), AppError> {
+    fs::write(repo_path.join(TOKEN_FILE), token)?;
+    Ok(())
+}
+
+pub fn load_token(repo_path: &Path) -> Option<String> {
+    fs::read_to_string(repo_path.join(TOKEN_FILE)).ok()
+}
 
 pub fn list_repos(base_dir: &PathBuf) -> Result<Vec<RepoInfo>, AppError> {
     let mut repos = Vec::new();
@@ -29,8 +59,26 @@ pub fn list_repos(base_dir: &PathBuf) -> Result<Vec<RepoInfo>, AppError> {
     Ok(repos)
 }
 
-pub fn clone_repo(url: &str, target_path: PathBuf) -> Result<(), AppError> {
-    Repository::clone(url, target_path)?;
+pub fn clone_repo(url: &str, target_path: PathBuf, token: Option<&str>) -> Result<(), AppError> {
+    match token {
+        Some(token) => {
+            let token = token.to_string();
+            let mut callbacks = git2::RemoteCallbacks::new();
+            callbacks.credentials(move |_url, _username, _allowed| {
+                git2::Cred::userpass_plaintext("x-access-token", &token)
+            });
+
+            let mut fetch_opts = git2::FetchOptions::new();
+            fetch_opts.remote_callbacks(callbacks);
+
+            let mut builder = git2::build::RepoBuilder::new();
+            builder.fetch_options(fetch_opts);
+            builder.clone(url, &target_path)?;
+        }
+        None => {
+            Repository::clone(url, target_path)?;
+        }
+    }
     Ok(())
 }
 #[allow(clippy::needless_pass_by_value)]

--- a/backend/src/repo.rs
+++ b/backend/src/repo.rs
@@ -10,16 +10,17 @@ use crate::parsers::get_parser_for_extension;
 const TOKEN_FILE: &str = ".dockix-token";
 
 pub fn validate_repo_url(url: &str) -> Result<(), AppError> {
-    if !url.starts_with("https://") && !url.starts_with("http://") {
+    let parsed = url::Url::parse(url).map_err(|_| {
+        AppError::InvalidInput("Invalid URL format".to_string())
+    })?;
+
+    if parsed.scheme() != "https" && parsed.scheme() != "http" {
         return Err(AppError::InvalidInput(
             "URL must use https:// or http://".to_string(),
         ));
     }
 
-    let after_scheme = url.split("://").nth(1).unwrap_or("");
-    let parts: Vec<&str> = after_scheme.splitn(2, '/').collect();
-
-    if parts.len() < 2 || parts[0].is_empty() || parts[1].is_empty() {
+    if parsed.host_str().is_none() || parsed.path().len() <= 1 {
         return Err(AppError::InvalidInput(
             "URL must include a host and path (e.g. https://github.com/user/repo)".to_string(),
         ));

--- a/backend/src/sync.rs
+++ b/backend/src/sync.rs
@@ -55,7 +55,19 @@ fn pull_repo(path: &Path) -> Result<(), String> {
     let mut remote = repo.find_remote("origin")
         .map_err(|e| e.to_string())?;
 
-    remote.fetch(&["refs/heads/*:refs/remotes/origin/*"], None, None)
+    let token = crate::repo::load_token(path);
+
+    let mut fetch_opts = git2::FetchOptions::new();
+    let mut callbacks = git2::RemoteCallbacks::new();
+
+    if let Some(token) = token {
+        callbacks.credentials(move |_url, _username, _allowed| {
+            git2::Cred::userpass_plaintext("x-access-token", &token)
+        });
+    }
+
+    fetch_opts.remote_callbacks(callbacks);
+    remote.fetch(&["refs/heads/*:refs/remotes/origin/*"], Some(&mut fetch_opts), None)
         .map_err(|e| e.to_string())?;
 
     let fetch_head = repo.find_reference("FETCH_HEAD")


### PR DESCRIPTION
Repos can now be cloned from other git providers like GitLab, Bitbucket or Codeberg, not just GitHub. Only HTTPS URLs are supported. Added an optional token field for private repo access. The token is stored per repo in a .dockix-token file so background sync can authenticate too. URL gets validated before cloning to catch bad input early. If a private repo is cloned without a token, the error message actually tells you that's the problem instead of returning a generic server error. Backwards compatible, existing requests without token still work fine. New code passes clippy pedantic.