### PR TITLE
Fix/clone blocking

### DIFF
--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -13,3 +13,4 @@ tree-sitter-javascript = "0.21"
 axum = "0.7"
 tokio = { version = "1.0", features = ["full"] }
 serde = { version = "1.0", features = ["derive"] }
+serde_json = "1"

--- a/backend/src/errors.rs
+++ b/backend/src/errors.rs
@@ -4,6 +4,7 @@ use axum::{
     Json,
 };
 use serde::Serialize;
+use std::fmt;
 
 #[derive(Serialize)]
 struct ErrorResponse {
@@ -17,6 +18,19 @@ pub enum AppError {
     GitError(String),
     ParseError(String),
     InternalError(String),
+}
+
+impl fmt::Display for AppError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            AppError::NotFound(msg)
+            | AppError::AlreadyExists(msg)
+            | AppError::InvalidInput(msg)
+            | AppError::GitError(msg)
+            | AppError::ParseError(msg)
+            | AppError::InternalError(msg) => write!(f, "{msg}"),
+        }
+    }
 }
 
 impl IntoResponse for AppError {
@@ -36,14 +50,22 @@ impl IntoResponse for AppError {
 
 impl From<git2::Error> for AppError {
     fn from(err: git2::Error) -> Self {
+        let msg = err.message();
+
         let is_auth_error = err.code() == git2::ErrorCode::Auth
-            || (err.class() == git2::ErrorClass::Http
-            && err.message().contains("401"));
+            || (err.class() == git2::ErrorClass::Http && msg.contains("401"))
+            || msg.contains("authentication replays");
 
         if is_auth_error {
             return AppError::InvalidInput(
                 "Authentication failed, the repository may be private. Try providing a token."
                     .to_string(),
+            );
+        }
+
+        if err.class() == git2::ErrorClass::Http && msg.contains("404") {
+            return AppError::InvalidInput(
+                "Repository not found, check the URL.".to_string(),
             );
         }
 

--- a/backend/src/errors.rs
+++ b/backend/src/errors.rs
@@ -12,8 +12,8 @@ struct ErrorResponse {
 }
 
 pub enum AppError {
-    NotFound(String),
-    AlreadyExists(String),
+    NotFound,
+    AlreadyExists,
     InvalidInput(String),
     GitError(String),
     ParseError(String),
@@ -23,9 +23,9 @@ pub enum AppError {
 impl fmt::Display for AppError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            AppError::NotFound(msg)
-            | AppError::AlreadyExists(msg)
-            | AppError::InvalidInput(msg)
+            AppError::NotFound => write!(f, "Not found"),
+            AppError::AlreadyExists => write!(f, "Already exists"),
+            AppError::InvalidInput(msg)
             | AppError::GitError(msg)
             | AppError::ParseError(msg)
             | AppError::InternalError(msg) => write!(f, "{msg}"),
@@ -35,12 +35,12 @@ impl fmt::Display for AppError {
 
 impl IntoResponse for AppError {
     fn into_response(self) -> axum::response::Response {
-        let (status, message) = match self {
-            AppError::NotFound(msg) => (StatusCode::NOT_FOUND, msg),
-            AppError::AlreadyExists(msg) => (StatusCode::CONFLICT, msg),
-            AppError::InvalidInput(msg) => (StatusCode::BAD_REQUEST, msg),
-            AppError::GitError(msg) | AppError::InternalError(msg) => (StatusCode::INTERNAL_SERVER_ERROR, msg),
-            AppError::ParseError(msg) => (StatusCode::UNPROCESSABLE_ENTITY, msg),
+        let (status, message) = match &self {
+            AppError::NotFound => (StatusCode::NOT_FOUND, "Not found".to_string()),
+            AppError::AlreadyExists => (StatusCode::CONFLICT, "Already exists".to_string()),
+            AppError::InvalidInput(msg) => (StatusCode::BAD_REQUEST, msg.clone()),
+            AppError::GitError(msg) | AppError::InternalError(msg) => (StatusCode::INTERNAL_SERVER_ERROR, msg.clone()),
+            AppError::ParseError(msg) => (StatusCode::UNPROCESSABLE_ENTITY, msg.clone()),
         };
 
         let body = ErrorResponse { error: message };

--- a/backend/src/handlers.rs
+++ b/backend/src/handlers.rs
@@ -27,33 +27,40 @@ pub async fn clone_handler(
 
     let name = payload.name.clone();
     let target_path = config.base_dir.join(&name);
-
-    // allow retrying a failed clone by cleaning up the old attempt
-    if repo::clone_error(&config.base_dir, &name).is_some() {
-        repo::clear_clone_error(&config.base_dir, &name);
-        let _ = fs::remove_dir_all(&target_path);
+    
+    if let Some(meta) = repo::load_meta(&config.base_dir, &name) {
+        if matches!(meta.status, crate::models::RepoStatus::Failed { .. }) {
+            let _ = fs::remove_dir_all(&target_path);
+        } else {
+            return Err(AppError::AlreadyExists);
+        }
     } else if target_path.exists() {
-        return Err(AppError::AlreadyExists("Directory already exists".to_string()));
+        return Err(AppError::AlreadyExists);
     }
-
-    repo::mark_cloning(&config.base_dir, &name);
 
     let url = payload.url;
     let token = payload.token;
     let depth = payload.depth.unwrap_or(1);
     let base_dir = config.base_dir.clone();
 
+    repo::save_meta(&config.base_dir, &name, &crate::models::RepoMeta {
+        token: token.clone(),
+        status: crate::models::RepoStatus::Cloning,
+    })?;
+
     tokio::task::spawn_blocking(move || {
-        match repo::clone_repo(&url, &target_path, token.as_deref(), depth) {
+        match repo::clone_repo(&url, &target_path, token.clone(), depth) {
             Ok(()) => {
-                repo::unmark_cloning(&base_dir, &name);
-                if let Some(ref token) = token {
-                    let _ = repo::save_token(&target_path, token);
-                }
+                let _ = repo::save_meta(&base_dir, &name, &crate::models::RepoMeta {
+                    token,
+                    status: crate::models::RepoStatus::Ready,
+                });
             }
             Err(e) => {
-                repo::unmark_cloning(&base_dir, &name);
-                repo::write_clone_error(&base_dir, &name, &e.to_string());
+                let _ = repo::save_meta(&base_dir, &name, &crate::models::RepoMeta {
+                    token,
+                    status: crate::models::RepoStatus::Failed { error: e.to_string() },
+                });
             }
         }
     });
@@ -68,7 +75,7 @@ pub async fn analyze_repo_handler(
     let repo_path = config.base_dir.join(&repo_name);
 
     if !repo_path.exists() {
-        return Err(AppError::NotFound("Repository not found".to_string()));
+        return Err(AppError::NotFound);
     }
 
     let parsed_data = tokio::task::spawn_blocking(move || {

--- a/backend/src/handlers.rs
+++ b/backend/src/handlers.rs
@@ -1,8 +1,10 @@
 use axum::{
     extract::State,
+    http::StatusCode,
     Json,
     response::IntoResponse,
 };
+use std::fs;
 use std::sync::Arc;
 use axum::extract::Path;
 
@@ -23,26 +25,40 @@ pub async fn clone_handler(
 ) -> Result<impl IntoResponse, AppError> {
     repo::validate_repo_url(&payload.url)?;
 
-    let url = payload.url;
-    let token = payload.token;
-    let target_path = config.base_dir.join(&payload.name);
+    let name = payload.name.clone();
+    let target_path = config.base_dir.join(&name);
 
-    if target_path.exists() {
+    // allow retrying a failed clone by cleaning up the old attempt
+    if repo::clone_error(&config.base_dir, &name).is_some() {
+        repo::clear_clone_error(&config.base_dir, &name);
+        let _ = fs::remove_dir_all(&target_path);
+    } else if target_path.exists() {
         return Err(AppError::AlreadyExists("Directory already exists".to_string()));
     }
 
-    let token_clone = token.clone();
-    let target_clone = target_path.clone();
+    repo::mark_cloning(&config.base_dir, &name);
+
+    let url = payload.url;
+    let token = payload.token;
+    let depth = payload.depth.unwrap_or(1);
+    let base_dir = config.base_dir.clone();
 
     tokio::task::spawn_blocking(move || {
-        repo::clone_repo(&url, target_clone, token_clone.as_deref())
-    }).await??;
+        match repo::clone_repo(&url, &target_path, token.as_deref(), depth) {
+            Ok(()) => {
+                repo::unmark_cloning(&base_dir, &name);
+                if let Some(ref token) = token {
+                    let _ = repo::save_token(&target_path, token);
+                }
+            }
+            Err(e) => {
+                repo::unmark_cloning(&base_dir, &name);
+                repo::write_clone_error(&base_dir, &name, &e.to_string());
+            }
+        }
+    });
 
-    if let Some(ref token) = token {
-        repo::save_token(&target_path, token)?;
-    }
-
-    Ok(Json("Repository cloned successfully"))
+    Ok((StatusCode::ACCEPTED, Json("Clone started, check GET /repos for status")))
 }
 
 pub async fn analyze_repo_handler(

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -26,6 +26,8 @@ async fn main() {
         fs::create_dir_all(&base_dir).expect("Failed to create base directory");
     }
 
+    repo::cleanup_stale_cloning(&base_dir);
+
     sync::start_sync_task(base_dir.clone());
 
     let config = Arc::new(AppConfig { base_dir });

--- a/backend/src/models.rs
+++ b/backend/src/models.rs
@@ -1,13 +1,28 @@
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
 
+#[derive(Serialize, Deserialize, Clone)]
+#[serde(tag = "status", rename_all = "lowercase")]
+pub enum RepoStatus {
+    Ready,
+    Cloning,
+    Failed { error: String },
+}
+
 #[derive(Serialize, Deserialize)]
+pub struct RepoMeta {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub token: Option<String>,
+    #[serde(flatten)]
+    pub status: RepoStatus,
+}
+
+#[derive(Serialize)]
 pub struct RepoInfo {
     pub name: String,
     pub path: String,
-    pub status: String,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub error: Option<String>,
+    #[serde(flatten)]
+    pub status: RepoStatus,
 }
 
 #[derive(Deserialize)]

--- a/backend/src/models.rs
+++ b/backend/src/models.rs
@@ -5,6 +5,9 @@ use std::path::PathBuf;
 pub struct RepoInfo {
     pub name: String,
     pub path: String,
+    pub status: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
 }
 
 #[derive(Deserialize)]
@@ -12,6 +15,7 @@ pub struct CloneRequest {
     pub url: String,
     pub name: String,
     pub token: Option<String>,
+    pub depth: Option<i32>,
 }
 
 #[derive(Serialize)]

--- a/backend/src/repo.rs
+++ b/backend/src/repo.rs
@@ -3,12 +3,26 @@ use std::path::{Path, PathBuf};
 use walkdir::WalkDir;
 
 use crate::errors::AppError;
-use crate::models::{RepoInfo, ParsedRepo};
+use crate::models::{RepoInfo, RepoMeta, RepoStatus, ParsedRepo};
 use crate::parsers::get_parser_for_extension;
 
-const TOKEN_FILE: &str = ".dockix-token";
-const CLONING_PREFIX: &str = ".dockix-cloning-";
-const ERROR_PREFIX: &str = ".dockix-clone-error-";
+const INFO_PREFIX: &str = ".dockix-";
+const INFO_SUFFIX: &str = ".json";
+
+fn info_path(base_dir: &Path, name: &str) -> PathBuf {
+    base_dir.join(format!("{INFO_PREFIX}{name}{INFO_SUFFIX}"))
+}
+
+pub fn load_meta(base_dir: &Path, name: &str) -> Option<RepoMeta> {
+    let data = fs::read_to_string(info_path(base_dir, name)).ok()?;
+    serde_json::from_str(&data).ok()
+}
+
+pub fn save_meta(base_dir: &Path, name: &str, meta: &RepoMeta) -> Result<(), AppError> {
+    let json = serde_json::to_string(meta).map_err(|e| AppError::InternalError(e.to_string()))?;
+    fs::write(info_path(base_dir, name), json)?;
+    Ok(())
+}
 
 pub fn validate_repo_url(url: &str) -> Result<(), AppError> {
     let parsed = url::Url::parse(url).map_err(|_| {
@@ -30,59 +44,40 @@ pub fn validate_repo_url(url: &str) -> Result<(), AppError> {
     Ok(())
 }
 
-pub fn save_token(repo_path: &Path, token: &str) -> Result<(), AppError> {
-    fs::write(repo_path.join(TOKEN_FILE), token)?;
-    Ok(())
-}
-
-pub fn load_token(repo_path: &Path) -> Option<String> {
-    fs::read_to_string(repo_path.join(TOKEN_FILE)).ok()
-}
-
-pub fn mark_cloning(base_dir: &Path, name: &str) {
-    let _ = fs::write(base_dir.join(format!("{CLONING_PREFIX}{name}")), "");
-}
-
-pub fn unmark_cloning(base_dir: &Path, name: &str) {
-    let _ = fs::remove_file(base_dir.join(format!("{CLONING_PREFIX}{name}")));
-}
-
-pub fn is_cloning(base_dir: &Path, name: &str) -> bool {
-    base_dir.join(format!("{CLONING_PREFIX}{name}")).exists()
-}
-
-pub fn write_clone_error(base_dir: &Path, name: &str, error: &str) {
-    let _ = fs::write(base_dir.join(format!("{ERROR_PREFIX}{name}")), error);
-}
-
-pub fn clone_error(base_dir: &Path, name: &str) -> Option<String> {
-    fs::read_to_string(base_dir.join(format!("{ERROR_PREFIX}{name}"))).ok()
-}
-
-pub fn clear_clone_error(base_dir: &Path, name: &str) {
-    let _ = fs::remove_file(base_dir.join(format!("{ERROR_PREFIX}{name}")));
-}
 pub fn cleanup_stale_cloning(base_dir: &Path) {
     let Ok(entries) = fs::read_dir(base_dir) else { return };
 
     for entry in entries.flatten() {
         let file_name = entry.file_name();
         let Some(name) = file_name.to_str() else { continue };
-        let Some(repo_name) = name.strip_prefix(CLONING_PREFIX) else { continue };
+
+        let Some(repo_name) = name
+            .strip_prefix(INFO_PREFIX)
+            .and_then(|n| n.strip_suffix(INFO_SUFFIX))
+        else {
+            continue;
+        };
 
         if repo_name.is_empty() {
             continue;
         }
 
-        let _ = fs::remove_file(entry.path());
+        let Some(meta) = load_meta(base_dir, repo_name) else { continue };
 
-        let repo_dir = base_dir.join(repo_name);
-        if repo_dir.exists() {
-            let _ = fs::remove_dir_all(&repo_dir);
+        if matches!(meta.status, RepoStatus::Cloning) {
+            let repo_dir = base_dir.join(repo_name);
+            if repo_dir.exists() {
+                let _ = fs::remove_dir_all(&repo_dir);
+            }
+
+            let _ = save_meta(base_dir, repo_name, &RepoMeta {
+                token: meta.token,
+                status: RepoStatus::Failed {
+                    error: "Clone interrupted by server shutdown".to_string(),
+                },
+            });
+            eprintln!("  Cleaned up interrupted clone: {repo_name}");
         }
-
-        write_clone_error(base_dir, repo_name, "Clone interrupted by server shutdown");
-        eprintln!("  Cleaned up interrupted clone: {repo_name}");
     }
 }
 
@@ -105,51 +100,33 @@ pub fn list_repos(base_dir: &PathBuf) -> Result<Vec<RepoInfo>, AppError> {
                 continue;
             }
 
-            if is_cloning(base_dir, name) {
+            if let Some(meta) = load_meta(base_dir, name) {
                 seen.insert(name.to_string());
                 repos.push(RepoInfo {
                     name: name.to_string(),
                     path: path.to_string_lossy().to_string(),
-                    status: "cloning".to_string(),
-                    error: None,
-                });
-            } else if let Some(err) = clone_error(base_dir, name) {
-                seen.insert(name.to_string());
-                repos.push(RepoInfo {
-                    name: name.to_string(),
-                    path: path.to_string_lossy().to_string(),
-                    status: "failed".to_string(),
-                    error: Some(err),
+                    status: meta.status,
                 });
             } else if path.join(".git").exists() {
                 seen.insert(name.to_string());
                 repos.push(RepoInfo {
                     name: name.to_string(),
                     path: path.to_string_lossy().to_string(),
-                    status: "ready".to_string(),
-                    error: None,
+                    status: RepoStatus::Ready,
                 });
             }
-        } else if let Some(name) = file_name.strip_prefix(CLONING_PREFIX)
-            && !name.is_empty() && !seen.contains(name)
+        } else if let Some(repo_name) = file_name
+            .strip_prefix(INFO_PREFIX)
+            .and_then(|n| n.strip_suffix(INFO_SUFFIX))
+            && !repo_name.is_empty() && !seen.contains(repo_name)
+            && let Some(meta) = load_meta(base_dir, repo_name)
+            && !matches!(meta.status, RepoStatus::Ready)
         {
-            seen.insert(name.to_string());
+            seen.insert(repo_name.to_string());
             repos.push(RepoInfo {
-                name: name.to_string(),
-                path: base_dir.join(name).to_string_lossy().to_string(),
-                status: "cloning".to_string(),
-                error: None,
-            });
-        } else if let Some(name) = file_name.strip_prefix(ERROR_PREFIX)
-            && !name.is_empty() && !seen.contains(name)
-        {
-            seen.insert(name.to_string());
-            let err = fs::read_to_string(&path).ok();
-            repos.push(RepoInfo {
-                name: name.to_string(),
-                path: base_dir.join(name).to_string_lossy().to_string(),
-                status: "failed".to_string(),
-                error: err,
+                name: repo_name.to_string(),
+                path: base_dir.join(repo_name).to_string_lossy().to_string(),
+                status: meta.status,
             });
         }
     }
@@ -157,12 +134,10 @@ pub fn list_repos(base_dir: &PathBuf) -> Result<Vec<RepoInfo>, AppError> {
     Ok(repos)
 }
 
-pub fn clone_repo(url: &str, target_path: &Path, token: Option<&str>, depth: i32) -> Result<(), AppError> {
+pub fn clone_repo(url: &str, target_path: &Path, token: Option<String>, depth: i32) -> Result<(), AppError> {
     let mut callbacks = git2::RemoteCallbacks::new();
 
-    let token_owned = token.map(String::from);
-    if let Some(ref token) = token_owned {
-        let token = token.clone();
+    if let Some(token) = token {
         callbacks.credentials(move |_url, _username, _allowed| {
             git2::Cred::userpass_plaintext("x-access-token", &token)
         });

--- a/backend/src/repo.rs
+++ b/backend/src/repo.rs
@@ -1,13 +1,14 @@
 use std::fs;
 use std::path::{Path, PathBuf};
 use walkdir::WalkDir;
-use git2::Repository;
 
 use crate::errors::AppError;
 use crate::models::{RepoInfo, ParsedRepo};
 use crate::parsers::get_parser_for_extension;
 
 const TOKEN_FILE: &str = ".dockix-token";
+const CLONING_PREFIX: &str = ".dockix-cloning-";
+const ERROR_PREFIX: &str = ".dockix-clone-error-";
 
 pub fn validate_repo_url(url: &str) -> Result<(), AppError> {
     let parsed = url::Url::parse(url).map_err(|_| {
@@ -38,21 +39,117 @@ pub fn load_token(repo_path: &Path) -> Option<String> {
     fs::read_to_string(repo_path.join(TOKEN_FILE)).ok()
 }
 
+pub fn mark_cloning(base_dir: &Path, name: &str) {
+    let _ = fs::write(base_dir.join(format!("{CLONING_PREFIX}{name}")), "");
+}
+
+pub fn unmark_cloning(base_dir: &Path, name: &str) {
+    let _ = fs::remove_file(base_dir.join(format!("{CLONING_PREFIX}{name}")));
+}
+
+pub fn is_cloning(base_dir: &Path, name: &str) -> bool {
+    base_dir.join(format!("{CLONING_PREFIX}{name}")).exists()
+}
+
+pub fn write_clone_error(base_dir: &Path, name: &str, error: &str) {
+    let _ = fs::write(base_dir.join(format!("{ERROR_PREFIX}{name}")), error);
+}
+
+pub fn clone_error(base_dir: &Path, name: &str) -> Option<String> {
+    fs::read_to_string(base_dir.join(format!("{ERROR_PREFIX}{name}"))).ok()
+}
+
+pub fn clear_clone_error(base_dir: &Path, name: &str) {
+    let _ = fs::remove_file(base_dir.join(format!("{ERROR_PREFIX}{name}")));
+}
+pub fn cleanup_stale_cloning(base_dir: &Path) {
+    let Ok(entries) = fs::read_dir(base_dir) else { return };
+
+    for entry in entries.flatten() {
+        let file_name = entry.file_name();
+        let Some(name) = file_name.to_str() else { continue };
+        let Some(repo_name) = name.strip_prefix(CLONING_PREFIX) else { continue };
+
+        if repo_name.is_empty() {
+            continue;
+        }
+
+        let _ = fs::remove_file(entry.path());
+
+        let repo_dir = base_dir.join(repo_name);
+        if repo_dir.exists() {
+            let _ = fs::remove_dir_all(&repo_dir);
+        }
+
+        write_clone_error(base_dir, repo_name, "Clone interrupted by server shutdown");
+        eprintln!("  Cleaned up interrupted clone: {repo_name}");
+    }
+}
+
 pub fn list_repos(base_dir: &PathBuf) -> Result<Vec<RepoInfo>, AppError> {
     let mut repos = Vec::new();
+    let mut seen = std::collections::HashSet::new();
 
     let entries = fs::read_dir(base_dir)?;
 
     for entry in entries.flatten() {
         let path = entry.path();
+        let Some(file_name) = path.file_name().and_then(|n| n.to_str()) else {
+            continue;
+        };
 
-        if path.is_dir()
-            && path.join(".git").exists()
-            && let Some(name) = path.file_name().and_then(|n| n.to_str())
+        if path.is_dir() {
+            let name = file_name;
+
+            if seen.contains(name) {
+                continue;
+            }
+
+            if is_cloning(base_dir, name) {
+                seen.insert(name.to_string());
+                repos.push(RepoInfo {
+                    name: name.to_string(),
+                    path: path.to_string_lossy().to_string(),
+                    status: "cloning".to_string(),
+                    error: None,
+                });
+            } else if let Some(err) = clone_error(base_dir, name) {
+                seen.insert(name.to_string());
+                repos.push(RepoInfo {
+                    name: name.to_string(),
+                    path: path.to_string_lossy().to_string(),
+                    status: "failed".to_string(),
+                    error: Some(err),
+                });
+            } else if path.join(".git").exists() {
+                seen.insert(name.to_string());
+                repos.push(RepoInfo {
+                    name: name.to_string(),
+                    path: path.to_string_lossy().to_string(),
+                    status: "ready".to_string(),
+                    error: None,
+                });
+            }
+        } else if let Some(name) = file_name.strip_prefix(CLONING_PREFIX)
+            && !name.is_empty() && !seen.contains(name)
         {
+            seen.insert(name.to_string());
             repos.push(RepoInfo {
                 name: name.to_string(),
-                path: path.to_string_lossy().to_string(),
+                path: base_dir.join(name).to_string_lossy().to_string(),
+                status: "cloning".to_string(),
+                error: None,
+            });
+        } else if let Some(name) = file_name.strip_prefix(ERROR_PREFIX)
+            && !name.is_empty() && !seen.contains(name)
+        {
+            seen.insert(name.to_string());
+            let err = fs::read_to_string(&path).ok();
+            repos.push(RepoInfo {
+                name: name.to_string(),
+                path: base_dir.join(name).to_string_lossy().to_string(),
+                status: "failed".to_string(),
+                error: err,
             });
         }
     }
@@ -60,26 +157,25 @@ pub fn list_repos(base_dir: &PathBuf) -> Result<Vec<RepoInfo>, AppError> {
     Ok(repos)
 }
 
-pub fn clone_repo(url: &str, target_path: PathBuf, token: Option<&str>) -> Result<(), AppError> {
-    match token {
-        Some(token) => {
-            let token = token.to_string();
-            let mut callbacks = git2::RemoteCallbacks::new();
-            callbacks.credentials(move |_url, _username, _allowed| {
-                git2::Cred::userpass_plaintext("x-access-token", &token)
-            });
+pub fn clone_repo(url: &str, target_path: &Path, token: Option<&str>, depth: i32) -> Result<(), AppError> {
+    let mut callbacks = git2::RemoteCallbacks::new();
 
-            let mut fetch_opts = git2::FetchOptions::new();
-            fetch_opts.remote_callbacks(callbacks);
-
-            let mut builder = git2::build::RepoBuilder::new();
-            builder.fetch_options(fetch_opts);
-            builder.clone(url, &target_path)?;
-        }
-        None => {
-            Repository::clone(url, target_path)?;
-        }
+    let token_owned = token.map(String::from);
+    if let Some(ref token) = token_owned {
+        let token = token.clone();
+        callbacks.credentials(move |_url, _username, _allowed| {
+            git2::Cred::userpass_plaintext("x-access-token", &token)
+        });
     }
+
+    let mut fetch_opts = git2::FetchOptions::new();
+    fetch_opts.remote_callbacks(callbacks);
+    fetch_opts.depth(depth);
+
+    let mut builder = git2::build::RepoBuilder::new();
+    builder.fetch_options(fetch_opts);
+    builder.clone(url, target_path)?;
+
     Ok(())
 }
 #[allow(clippy::needless_pass_by_value)]

--- a/backend/src/sync.rs
+++ b/backend/src/sync.rs
@@ -41,6 +41,12 @@ fn sync_all_repos(base_dir: &Path) {
             .and_then(|n| n.to_str())
             .unwrap_or("unknown");
 
+        if crate::repo::is_cloning(base_dir, name)
+            || crate::repo::clone_error(base_dir, name).is_some()
+        {
+            continue;
+        }
+
         match pull_repo(&path) {
             Ok(()) => println!("  Synced: {name}"),
             Err(e) => eprintln!("  Failed to sync {name}: {e}"),

--- a/backend/src/sync.rs
+++ b/backend/src/sync.rs
@@ -41,27 +41,32 @@ fn sync_all_repos(base_dir: &Path) {
             .and_then(|n| n.to_str())
             .unwrap_or("unknown");
 
-        if crate::repo::is_cloning(base_dir, name)
-            || crate::repo::clone_error(base_dir, name).is_some()
+        if let Some(meta) = crate::repo::load_meta(base_dir, name)
+            && !matches!(meta.status, crate::models::RepoStatus::Ready)
         {
             continue;
         }
 
-        match pull_repo(&path) {
+        match pull_repo(base_dir, &path) {
             Ok(()) => println!("  Synced: {name}"),
             Err(e) => eprintln!("  Failed to sync {name}: {e}"),
         }
     }
 }
 
-fn pull_repo(path: &Path) -> Result<(), String> {
+fn pull_repo(base_dir: &Path, path: &Path) -> Result<(), String> {
     let repo = git2::Repository::open(path)
         .map_err(|e| e.to_string())?;
 
     let mut remote = repo.find_remote("origin")
         .map_err(|e| e.to_string())?;
 
-    let token = crate::repo::load_token(path);
+    let name = path.file_name()
+        .and_then(|n| n.to_str())
+        .unwrap_or("");
+
+    let token = crate::repo::load_meta(base_dir, name)
+        .and_then(|meta| meta.token);
 
     let mut fetch_opts = git2::FetchOptions::new();
     let mut callbacks = git2::RemoteCallbacks::new();


### PR DESCRIPTION
Cloning large repos used to block the entire server until the download finished. Other endpoints like /repos and /analyze became unresponsive too, and the client would eventually time out. The repo would still end up on disk after a while but with no feedback to the user.
Clone endpoint now returns 202 immediately and runs the download in the background. Status is tracked per repo through GET /repos which reports "cloning", "ready" or "failed" with an error message if something went wrong. State is stored as marker files in the repositories directory so it survives restarts. On startup the server detects and cleans up any clones that were interrupted by a crash, marking them as failed so they can be retried.
Clones default to shallow (depth 1) since Dockix only needs the latest code for parsing, not git history. Depth is configurable through an optional field in the request body. 
Failed clones can be retried by sending the same clone request again, the old attempt gets cleaned up automatically. Sync skips repos that are still cloning or have failed. Git errors like wrong tokens or bad URLs now show friendlier messages instead of raw git2 internals.
Passes clippy pedantic.
Depends on #27 , merge that first.
Closes #28