### PR TITLE
expose sync status per repo via API

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -12,6 +12,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -27,6 +36,12 @@ name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
+name = "autocfg"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "axum"
@@ -88,8 +103,10 @@ name = "backend"
 version = "0.1.0"
 dependencies = [
  "axum",
+ "chrono",
  "git2",
  "serde",
+ "serde_json",
  "tokio",
  "tree-sitter",
  "tree-sitter-javascript",
@@ -103,6 +120,12 @@ name = "bitflags"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+
+[[package]]
+name = "bumpalo"
+version = "3.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 
 [[package]]
 name = "bytes"
@@ -126,6 +149,26 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "chrono"
+version = "0.4.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
+dependencies = [
+ "iana-time-zone",
+ "js-sys",
+ "num-traits",
+ "serde",
+ "wasm-bindgen",
+ "windows-link",
+]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "displaydoc"
@@ -299,6 +342,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "iana-time-zone"
+version = "0.1.65"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "icu_collections"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -417,6 +484,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "js-sys"
+version = "0.3.95"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2964e92d1d9dc3364cae4d718d93f227e3abb088e747d92e0395bfdedf1c12ca"
+dependencies = [
+ "once_cell",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "libc"
 version = "0.2.183"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -510,6 +587,15 @@ dependencies = [
  "libc",
  "wasi",
  "windows-sys",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
 ]
 
 [[package]]
@@ -985,6 +1071,51 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-bindgen"
+version = "0.2.118"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf938a0bacb0469e83c1e148908bd7d5a6010354cf4fb73279b7447422e3a89"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.118"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eeff24f84126c0ec2db7a449f0c2ec963c6a49efe0698c4242929da037ca28ed"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.118"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d08065faf983b2b80a79fd87d8254c409281cf7de75fc4b773019824196c904"
+dependencies = [
+ "bumpalo",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.118"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fd04d9e306f1907bd13c6361b5c6bfc7b3b3c095ed3f8a9246390f8dbdee129"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
 name = "winapi-util"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -994,10 +1125,63 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-core"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-result"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
+dependencies = [
+ "windows-link",
+]
 
 [[package]]
 name = "windows-sys"

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -14,3 +14,4 @@ axum = "0.7"
 tokio = { version = "1.0", features = ["full"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1"
+chrono = { version = "0.4", features = ["serde"] }

--- a/backend/src/handlers.rs
+++ b/backend/src/handlers.rs
@@ -27,9 +27,9 @@ pub async fn clone_handler(
 
     let name = payload.name.clone();
     let target_path = config.base_dir.join(&name);
-    
+
     if let Some(meta) = repo::load_meta(&config.base_dir, &name) {
-        if matches!(meta.status, crate::models::RepoStatus::Failed { .. }) {
+        if matches!(meta.status, crate::models::RepoStatus::CloneFailed { .. }) {
             let _ = fs::remove_dir_all(&target_path);
         } else {
             return Err(AppError::AlreadyExists);
@@ -53,13 +53,17 @@ pub async fn clone_handler(
             Ok(()) => {
                 let _ = repo::save_meta(&base_dir, &name, &crate::models::RepoMeta {
                     token,
-                    status: crate::models::RepoStatus::Ready,
+                    status: crate::models::RepoStatus::Ready {
+                        last_synced_at: chrono::Utc::now(),
+                    },
                 });
             }
             Err(e) => {
                 let _ = repo::save_meta(&base_dir, &name, &crate::models::RepoMeta {
                     token,
-                    status: crate::models::RepoStatus::Failed { error: e.to_string() },
+                    status: crate::models::RepoStatus::CloneFailed {
+                        error: e.to_string(),
+                    },
                 });
             }
         }

--- a/backend/src/models.rs
+++ b/backend/src/models.rs
@@ -1,12 +1,19 @@
+use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
 
 #[derive(Serialize, Deserialize, Clone)]
-#[serde(tag = "status", rename_all = "lowercase")]
+#[serde(tag = "status", rename_all = "snake_case")]
 pub enum RepoStatus {
-    Ready,
+    Ready { last_synced_at: DateTime<Utc> },
     Cloning,
-    Failed { error: String },
+    Syncing { last_synced_at: DateTime<Utc> },
+    CloneFailed { error: String },
+    SyncFailed {
+        last_synced_at: DateTime<Utc>,
+        error: String,
+        failed_at: DateTime<Utc>,
+    },
 }
 
 #[derive(Serialize, Deserialize)]

--- a/backend/src/repo.rs
+++ b/backend/src/repo.rs
@@ -64,19 +64,29 @@ pub fn cleanup_stale_cloning(base_dir: &Path) {
 
         let Some(meta) = load_meta(base_dir, repo_name) else { continue };
 
-        if matches!(meta.status, RepoStatus::Cloning) {
-            let repo_dir = base_dir.join(repo_name);
-            if repo_dir.exists() {
-                let _ = fs::remove_dir_all(&repo_dir);
-            }
+        match meta.status {
+            RepoStatus::Cloning => {
+                let repo_dir = base_dir.join(repo_name);
+                if repo_dir.exists() {
+                    let _ = fs::remove_dir_all(&repo_dir);
+                }
 
-            let _ = save_meta(base_dir, repo_name, &RepoMeta {
-                token: meta.token,
-                status: RepoStatus::Failed {
-                    error: "Clone interrupted by server shutdown".to_string(),
-                },
-            });
-            eprintln!("  Cleaned up interrupted clone: {repo_name}");
+                let _ = save_meta(base_dir, repo_name, &RepoMeta {
+                    token: meta.token,
+                    status: RepoStatus::CloneFailed {
+                        error: "Clone interrupted by server shutdown".to_string(),
+                    },
+                });
+                eprintln!("  Cleaned up interrupted clone: {repo_name}");
+            }
+            RepoStatus::Syncing { last_synced_at } => {
+                let _ = save_meta(base_dir, repo_name, &RepoMeta {
+                    token: meta.token,
+                    status: RepoStatus::Ready { last_synced_at },
+                });
+                eprintln!("  Restored interrupted sync: {repo_name}");
+            }
+            _ => {}
         }
     }
 }
@@ -107,20 +117,12 @@ pub fn list_repos(base_dir: &PathBuf) -> Result<Vec<RepoInfo>, AppError> {
                     path: path.to_string_lossy().to_string(),
                     status: meta.status,
                 });
-            } else if path.join(".git").exists() {
-                seen.insert(name.to_string());
-                repos.push(RepoInfo {
-                    name: name.to_string(),
-                    path: path.to_string_lossy().to_string(),
-                    status: RepoStatus::Ready,
-                });
             }
         } else if let Some(repo_name) = file_name
             .strip_prefix(INFO_PREFIX)
             .and_then(|n| n.strip_suffix(INFO_SUFFIX))
             && !repo_name.is_empty() && !seen.contains(repo_name)
             && let Some(meta) = load_meta(base_dir, repo_name)
-            && !matches!(meta.status, RepoStatus::Ready)
         {
             seen.insert(repo_name.to_string());
             repos.push(RepoInfo {

--- a/backend/src/sync.rs
+++ b/backend/src/sync.rs
@@ -41,15 +41,44 @@ fn sync_all_repos(base_dir: &Path) {
             .and_then(|n| n.to_str())
             .unwrap_or("unknown");
 
-        if let Some(meta) = crate::repo::load_meta(base_dir, name)
-            && !matches!(meta.status, crate::models::RepoStatus::Ready)
-        {
+        let Some(meta) = crate::repo::load_meta(base_dir, name) else { continue };
+
+        let (crate::models::RepoStatus::Ready { last_synced_at }
+        | crate::models::RepoStatus::SyncFailed { last_synced_at, .. }) = meta.status
+        else {
             continue;
-        }
+        };
+
+        let _ = crate::repo::save_meta(base_dir, name, &crate::models::RepoMeta {
+            token: meta.token,
+            status: crate::models::RepoStatus::Syncing { last_synced_at },
+        });
 
         match pull_repo(base_dir, &path) {
-            Ok(()) => println!("  Synced: {name}"),
-            Err(e) => eprintln!("  Failed to sync {name}: {e}"),
+            Ok(()) => {
+                if let Some(meta) = crate::repo::load_meta(base_dir, name) {
+                    let _ = crate::repo::save_meta(base_dir, name, &crate::models::RepoMeta {
+                        token: meta.token,
+                        status: crate::models::RepoStatus::Ready {
+                            last_synced_at: chrono::Utc::now(),
+                        },
+                    });
+                }
+                println!("  Synced: {name}");
+            }
+            Err(e) => {
+                if let Some(meta) = crate::repo::load_meta(base_dir, name) {
+                    let _ = crate::repo::save_meta(base_dir, name, &crate::models::RepoMeta {
+                        token: meta.token,
+                        status: crate::models::RepoStatus::SyncFailed {
+                            last_synced_at,
+                            error: e.clone(),
+                            failed_at: chrono::Utc::now(),
+                        },
+                    });
+                }
+                eprintln!("  Failed to sync {name}: {e}");
+            }
         }
     }
 }


### PR DESCRIPTION
Added last_synced_at and last_sync_error to the per-repo meta files and GET /repos response, both only appear when set. Successful sync saves the timestamp and clears any previous error, failed sync saves the error but keeps the old timestamp to indicate when the last successful clone happened. Clone also sets the time stamp upon completion, since that's technically the first sync. Passes clippy pedantic. 
Closes #29 