### PR TITLE
Feature/clone throttle

### DIFF
--- a/backend/src/errors.rs
+++ b/backend/src/errors.rs
@@ -14,6 +14,7 @@ struct ErrorResponse {
 pub enum AppError {
     NotFound,
     AlreadyExists,
+    TooManyClones,
     InvalidInput(String),
     GitError(String),
     ParseError(String),
@@ -25,6 +26,7 @@ impl fmt::Display for AppError {
         match self {
             AppError::NotFound => write!(f, "Not found"),
             AppError::AlreadyExists => write!(f, "Already exists"),
+            AppError::TooManyClones => write!(f, "Too many clones in progress"),
             AppError::InvalidInput(msg)
             | AppError::GitError(msg)
             | AppError::ParseError(msg)
@@ -38,6 +40,7 @@ impl IntoResponse for AppError {
         let (status, message) = match &self {
             AppError::NotFound => (StatusCode::NOT_FOUND, "Not found".to_string()),
             AppError::AlreadyExists => (StatusCode::CONFLICT, "Already exists".to_string()),
+            AppError::TooManyClones => (StatusCode::TOO_MANY_REQUESTS, "Too many clones in progress, try again later".to_string()),
             AppError::InvalidInput(msg) => (StatusCode::BAD_REQUEST, msg.clone()),
             AppError::GitError(msg) | AppError::InternalError(msg) => (StatusCode::INTERNAL_SERVER_ERROR, msg.clone()),
             AppError::ParseError(msg) => (StatusCode::UNPROCESSABLE_ENTITY, msg.clone()),

--- a/backend/src/handlers.rs
+++ b/backend/src/handlers.rs
@@ -38,6 +38,10 @@ pub async fn clone_handler(
         return Err(AppError::AlreadyExists);
     }
 
+    let permit = Arc::clone(&config.clone_semaphore)
+        .try_acquire_owned()
+        .map_err(|_| AppError::TooManyClones)?;
+
     let url = payload.url;
     let token = payload.token;
     let depth = payload.depth.unwrap_or(1);
@@ -49,6 +53,8 @@ pub async fn clone_handler(
     })?;
 
     tokio::task::spawn_blocking(move || {
+        let _permit = permit;
+
         match repo::clone_repo(&url, &target_path, token.clone(), depth) {
             Ok(()) => {
                 let _ = repo::save_meta(&base_dir, &name, &crate::models::RepoMeta {

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -14,6 +14,7 @@ use axum::{
 use std::fs;
 use std::path::PathBuf;
 use std::sync::Arc;
+use tokio::sync::Semaphore;
 
 use crate::models::AppConfig;
 use crate::handlers::{clone_handler, list_repos_handler, analyze_repo_handler};
@@ -30,7 +31,15 @@ async fn main() {
 
     sync::start_sync_task(base_dir.clone());
 
-    let config = Arc::new(AppConfig { base_dir });
+    let max_clones: usize = std::env::var("DOCKIX_MAX_CONCURRENT_CLONES")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(3);
+
+    let config = Arc::new(AppConfig {
+        base_dir,
+        clone_semaphore: Arc::new(Semaphore::new(max_clones)),
+    });
 
     let app = Router::new()
         .route("/clone", post(clone_handler))

--- a/backend/src/models.rs
+++ b/backend/src/models.rs
@@ -1,6 +1,8 @@
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
+use std::sync::Arc;
+use tokio::sync::Semaphore;
 
 #[derive(Serialize, Deserialize, Clone)]
 #[serde(tag = "status", rename_all = "snake_case")]
@@ -71,4 +73,5 @@ pub struct FunctionDoc {
 
 pub struct AppConfig {
     pub base_dir: PathBuf,
+    pub clone_semaphore: Arc<Semaphore>,
 }


### PR DESCRIPTION
Clone endpoint now limits concurrent clones using a semaphore. Defaults to 3, configurable via DOCKIX_MAX_CONCURRENT_CLONES env var. Excess requests get a 429. Permit is held for the duration of the clone and released when done. Passes clippy pedantic.