### PR TITLE
Add delete endpoint and handle orphaned meta files

### DIFF
--- a/backend/src/errors.rs
+++ b/backend/src/errors.rs
@@ -15,6 +15,7 @@ pub enum AppError {
     NotFound,
     AlreadyExists,
     TooManyClones,
+    CloneInProgress,
     InvalidInput(String),
     GitError(String),
     ParseError(String),
@@ -27,6 +28,7 @@ impl fmt::Display for AppError {
             AppError::NotFound => write!(f, "Not found"),
             AppError::AlreadyExists => write!(f, "Already exists"),
             AppError::TooManyClones => write!(f, "Too many clones in progress"),
+            AppError::CloneInProgress => write!(f, "Clone is in progress"),
             AppError::InvalidInput(msg)
             | AppError::GitError(msg)
             | AppError::ParseError(msg)
@@ -41,6 +43,7 @@ impl IntoResponse for AppError {
             AppError::NotFound => (StatusCode::NOT_FOUND, "Not found".to_string()),
             AppError::AlreadyExists => (StatusCode::CONFLICT, "Already exists".to_string()),
             AppError::TooManyClones => (StatusCode::TOO_MANY_REQUESTS, "Too many clones in progress, try again later".to_string()),
+            AppError::CloneInProgress => (StatusCode::CONFLICT, "Cannot delete while clone is in progress".to_string()),
             AppError::InvalidInput(msg) => (StatusCode::BAD_REQUEST, msg.clone()),
             AppError::GitError(msg) | AppError::InternalError(msg) => (StatusCode::INTERNAL_SERVER_ERROR, msg.clone()),
             AppError::ParseError(msg) => (StatusCode::UNPROCESSABLE_ENTITY, msg.clone()),

--- a/backend/src/handlers.rs
+++ b/backend/src/handlers.rs
@@ -78,6 +78,37 @@ pub async fn clone_handler(
     Ok((StatusCode::ACCEPTED, Json("Clone started, check GET /repos for status")))
 }
 
+pub async fn delete_repo_handler(
+    State(config): State<Arc<AppConfig>>,
+    Path(repo_name): Path<String>,
+) -> Result<impl IntoResponse, AppError> {
+    let repo_path = config.base_dir.join(&repo_name);
+    let meta = repo::load_meta(&config.base_dir, &repo_name);
+
+    if let Some(ref meta) = meta
+        && matches!(meta.status, crate::models::RepoStatus::Cloning)
+    {
+        return Err(AppError::CloneInProgress);
+    }
+
+    let dir_exists = repo_path.exists();
+    let meta_exists = meta.is_some();
+
+    if !dir_exists && !meta_exists {
+        return Err(AppError::NotFound);
+    }
+
+    if dir_exists {
+        fs::remove_dir_all(&repo_path)?;
+    }
+
+    if meta_exists {
+        repo::delete_meta(&config.base_dir, &repo_name)?;
+    }
+
+    Ok(StatusCode::NO_CONTENT)
+}
+
 pub async fn analyze_repo_handler(
     State(config): State<Arc<AppConfig>>,
     Path(repo_name): Path<String>,

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -8,7 +8,7 @@ mod sync;
 
 use axum::{
     middleware,
-    routing::{get, post},
+    routing::{delete, get, post},
     Router,
 };
 use std::fs;
@@ -17,7 +17,7 @@ use std::sync::Arc;
 use tokio::sync::Semaphore;
 
 use crate::models::AppConfig;
-use crate::handlers::{clone_handler, list_repos_handler, analyze_repo_handler};
+use crate::handlers::{clone_handler, list_repos_handler, analyze_repo_handler, delete_repo_handler};
 
 #[tokio::main]
 async fn main() {
@@ -44,6 +44,7 @@ async fn main() {
     let app = Router::new()
         .route("/clone", post(clone_handler))
         .route("/repos", get(list_repos_handler))
+        .route("/repos/:repo_name", delete(delete_repo_handler))
         .route("/analyze/:repo_name", get(analyze_repo_handler))
         .layer(middleware::from_fn(auth::require_api_key))
         .with_state(config);

--- a/backend/src/repo.rs
+++ b/backend/src/repo.rs
@@ -24,6 +24,14 @@ pub fn save_meta(base_dir: &Path, name: &str, meta: &RepoMeta) -> Result<(), App
     Ok(())
 }
 
+pub fn delete_meta(base_dir: &Path, name: &str) -> Result<(), AppError> {
+    let path = info_path(base_dir, name);
+    if path.exists() {
+        fs::remove_file(path)?;
+    }
+    Ok(())
+}
+
 pub fn validate_repo_url(url: &str) -> Result<(), AppError> {
     let parsed = url::Url::parse(url).map_err(|_| {
         AppError::InvalidInput("Invalid URL format".to_string())
@@ -63,12 +71,12 @@ pub fn cleanup_stale_cloning(base_dir: &Path) {
         }
 
         let Some(meta) = load_meta(base_dir, repo_name) else { continue };
+        let dir_exists = base_dir.join(repo_name).exists();
 
         match meta.status {
             RepoStatus::Cloning => {
-                let repo_dir = base_dir.join(repo_name);
-                if repo_dir.exists() {
-                    let _ = fs::remove_dir_all(&repo_dir);
+                if dir_exists {
+                    let _ = fs::remove_dir_all(base_dir.join(repo_name));
                 }
 
                 let _ = save_meta(base_dir, repo_name, &RepoMeta {
@@ -85,6 +93,15 @@ pub fn cleanup_stale_cloning(base_dir: &Path) {
                     status: RepoStatus::Ready { last_synced_at },
                 });
                 eprintln!("  Restored interrupted sync: {repo_name}");
+            }
+            RepoStatus::Ready { .. } | RepoStatus::SyncFailed { .. } if !dir_exists => {
+                let _ = save_meta(base_dir, repo_name, &RepoMeta {
+                    token: meta.token,
+                    status: RepoStatus::CloneFailed {
+                        error: "Repository directory is missing".to_string(),
+                    },
+                });
+                eprintln!("  Marked orphaned meta as failed: {repo_name}");
             }
             _ => {}
         }
@@ -125,10 +142,21 @@ pub fn list_repos(base_dir: &PathBuf) -> Result<Vec<RepoInfo>, AppError> {
             && let Some(meta) = load_meta(base_dir, repo_name)
         {
             seen.insert(repo_name.to_string());
+
+            let repo_dir = base_dir.join(repo_name);
+            let status = match meta.status {
+                RepoStatus::Ready { .. } | RepoStatus::SyncFailed { .. } if !repo_dir.exists() => {
+                    RepoStatus::CloneFailed {
+                        error: "Repository directory is missing".to_string(),
+                    }
+                }
+                other => other,
+            };
+
             repos.push(RepoInfo {
                 name: repo_name.to_string(),
-                path: base_dir.join(repo_name).to_string_lossy().to_string(),
-                status: meta.status,
+                path: repo_dir.to_string_lossy().to_string(),
+                status,
             });
         }
     }


### PR DESCRIPTION
Added DELETE /repos/:repo_name to remove a cloned repo and its meta file. Returns 409 if the repo is currently being cloned, 404 if it doesn't exist, 204 on success. Orphaned meta files (directory missing but meta left behind) are now detected at startup and at runtime through GET /repos, marked as clone_failed so they're visible and deletable. Folders without a meta file are ignored. Passes clippy pedantic.
Closes #33 