### PR TITLE
rework models and rewrite python parser for data mapping

### DIFF
--- a/backend/src/models.rs
+++ b/backend/src/models.rs
@@ -52,23 +52,31 @@ pub struct ParsedRepo {
 #[derive(Serialize)]
 pub struct ParsedFile {
     pub file_path: String,
+    pub language: String,
     pub classes: Vec<ClassDoc>,
     pub functions: Vec<FunctionDoc>,
-    // TODO: add language field for frontend
 }
 
 #[derive(Serialize)]
 pub struct ClassDoc {
     pub name: String,
     pub docstring: Option<String>,
-    // TODO: add methods: Vec<FunctionDoc>
+    pub methods: Vec<FunctionDoc>,
 }
 
 #[derive(Serialize)]
 pub struct FunctionDoc {
     pub name: String,
     pub docstring: Option<String>,
-    // TODO: add parameters and return_type
+    pub parameters: Vec<ParameterDoc>,
+    pub return_type: Option<String>,
+}
+
+#[derive(Serialize)]
+pub struct ParameterDoc {
+    pub name: String,
+    pub type_annotation: Option<String>,
+    pub default_value: Option<String>,
 }
 
 pub struct AppConfig {

--- a/backend/src/parsers/javascript.rs
+++ b/backend/src/parsers/javascript.rs
@@ -22,7 +22,7 @@ impl LanguageParser for JavaScriptParser {
 
         let tree = parser.parse(&source_code, None)
             .ok_or(AppError::ParseError("Failed to parse JavaScript code".to_string()))?;
-        
+
         // TODO: handle arrow functions (const foo = () => {})
         // TODO: handle exported functions (export function, export default)
         let query_string = r"
@@ -77,7 +77,6 @@ impl LanguageParser for JavaScriptParser {
                         is_class = true;
                     }
                     "func.docstring" | "class.docstring" => {
-                        // strip JSDoc syntax: /**, */, leading * on each line
                         let cleaned = text
                             .trim_start_matches("/**")
                             .trim_start_matches("/*")
@@ -99,10 +98,15 @@ impl LanguageParser for JavaScriptParser {
             if !name.is_empty() {
                 if is_class {
                     if seen_classes.insert(name.clone()) {
-                        classes.push(ClassDoc { name, docstring });
+                        classes.push(ClassDoc { name, docstring, methods: Vec::new() });
                     }
                 } else if seen_functions.insert(name.clone()) {
-                    functions.push(FunctionDoc { name, docstring });
+                    functions.push(FunctionDoc {
+                        name,
+                        docstring,
+                        parameters: Vec::new(),
+                        return_type: None,
+                    });
                 }
             }
         }
@@ -114,6 +118,7 @@ impl LanguageParser for JavaScriptParser {
 
         Ok(ParsedFile {
             file_path: relative_path,
+            language: "javascript".to_string(),
             classes,
             functions,
         })

--- a/backend/src/parsers/python.rs
+++ b/backend/src/parsers/python.rs
@@ -1,8 +1,8 @@
 use std::fs;
-use tree_sitter::{Parser, Query, QueryCursor};
+use tree_sitter::Parser;
 
 use crate::errors::AppError;
-use crate::models::{ParsedFile, ClassDoc, FunctionDoc};
+use crate::models::{ClassDoc, FunctionDoc, ParameterDoc, ParsedFile};
 use super::LanguageParser;
 
 pub struct PythonParser;
@@ -14,7 +14,7 @@ impl LanguageParser for PythonParser {
         repo_base: &std::path::Path,
     ) -> Result<ParsedFile, AppError> {
         let source_code = fs::read_to_string(file_path)?;
-        let source_bytes = source_code.as_bytes();
+        let source = source_code.as_bytes();
 
         let mut parser = Parser::new();
         let language = tree_sitter_python::language();
@@ -23,54 +23,41 @@ impl LanguageParser for PythonParser {
         let tree = parser.parse(&source_code, None)
             .ok_or(AppError::ParseError("Failed to parse Python code".to_string()))?;
 
-        let query_string = r"
-            (function_definition
-                name: (identifier) @func.name
-                body: (block (expression_statement (string) @func.docstring))?
-            )
-            (class_definition
-                name: (identifier) @class.name
-                body: (block (expression_statement (string) @class.docstring))?
-            )
-        ";
-
-        let query = Query::new(&language, query_string)
-            .map_err(|e| AppError::ParseError(format!("Invalid query: {e}")))?;
-        let mut cursor = QueryCursor::new();
-        let matches = cursor.matches(&query, tree.root_node(), source_bytes);
-
+        let root = tree.root_node();
         let mut functions = Vec::new();
         let mut classes = Vec::new();
 
-        for m in matches {
-            let mut name = String::new();
-            let mut docstring = None;
-            let mut is_class = false;
-
-            for capture in m.captures {
-                let capture_name = query.capture_names()[capture.index as usize];
-                let text = capture.node.utf8_text(source_bytes).unwrap_or("").to_string();
-
-                match capture_name {
-                    "func.name" => name = text,
-                    "class.name" => {
-                        name = text;
-                        is_class = true;
+        let mut cursor = root.walk();
+        for child in root.children(&mut cursor) {
+            match child.kind() {
+                "function_definition" => {
+                    if let Some(func) = extract_function(&child, source) {
+                        functions.push(func);
                     }
-                    "func.docstring" | "class.docstring" => {
-                        let cleaned = text.trim_matches(|c| c == '"' || c == '\'').to_string();
-                        docstring = Some(cleaned);
+                }
+                "class_definition" => {
+                    if let Some(class) = extract_class(&child, source) {
+                        classes.push(class);
                     }
-                    _ => {}
                 }
-            }
-
-            if !name.is_empty() {
-                if is_class {
-                    classes.push(ClassDoc { name, docstring });
-                } else {
-                    functions.push(FunctionDoc { name, docstring });
+                "decorated_definition" => {
+                    if let Some(inner) = child.child_by_field_name("definition") {
+                        match inner.kind() {
+                            "function_definition" => {
+                                if let Some(func) = extract_function(&inner, source) {
+                                    functions.push(func);
+                                }
+                            }
+                            "class_definition" => {
+                                if let Some(class) = extract_class(&inner, source) {
+                                    classes.push(class);
+                                }
+                            }
+                            _ => {}
+                        }
+                    }
                 }
+                _ => {}
             }
         }
 
@@ -81,8 +68,171 @@ impl LanguageParser for PythonParser {
 
         Ok(ParsedFile {
             file_path: relative_path,
+            language: "python".to_string(),
             classes,
             functions,
         })
     }
+}
+
+fn extract_class(node: &tree_sitter::Node, source: &[u8]) -> Option<ClassDoc> {
+    let name = node_text(&node.child_by_field_name("name")?, source);
+    let docstring = extract_docstring(node, source);
+
+    let mut methods = Vec::new();
+    if let Some(body) = node.child_by_field_name("body") {
+        let mut cursor = body.walk();
+        for child in body.children(&mut cursor) {
+            match child.kind() {
+                "function_definition" => {
+                    if let Some(func) = extract_function(&child, source) {
+                        methods.push(func);
+                    }
+                }
+                "decorated_definition" => {
+                    if let Some(inner) = child.child_by_field_name("definition")
+                        && inner.kind() == "function_definition"
+                        && let Some(func) = extract_function(&inner, source)
+                    {
+                        methods.push(func);
+                    }
+                }
+                _ => {}
+            }
+        }
+    }
+
+    Some(ClassDoc { name, docstring, methods })
+}
+
+fn extract_function(node: &tree_sitter::Node, source: &[u8]) -> Option<FunctionDoc> {
+    let name = node_text(&node.child_by_field_name("name")?, source);
+    let docstring = extract_docstring(node, source);
+    let parameters = extract_parameters(node, source);
+    let return_type = node.child_by_field_name("return_type")
+        .map(|n| node_text(&n, source));
+
+    Some(FunctionDoc { name, docstring, parameters, return_type })
+}
+
+fn extract_docstring(node: &tree_sitter::Node, source: &[u8]) -> Option<String> {
+    let body = node.child_by_field_name("body")?;
+    let first_stmt = body.named_child(0)?;
+
+    if first_stmt.kind() != "expression_statement" {
+        return None;
+    }
+
+    let expr = first_stmt.named_child(0)?;
+    if expr.kind() != "string" {
+        return None;
+    }
+
+    let text = expr.utf8_text(source).ok()?;
+    let cleaned = strip_python_quotes(text);
+    if cleaned.is_empty() { None } else { Some(cleaned) }
+}
+
+fn extract_parameters(func_node: &tree_sitter::Node, source: &[u8]) -> Vec<ParameterDoc> {
+    let Some(params_node) = func_node.child_by_field_name("parameters") else {
+        return Vec::new();
+    };
+
+    let mut params = Vec::new();
+    let mut cursor = params_node.walk();
+
+    for child in params_node.named_children(&mut cursor) {
+        let param = match child.kind() {
+            "identifier" => ParameterDoc {
+                name: node_text(&child, source),
+                type_annotation: None,
+                default_value: None,
+            },
+            "typed_parameter" => {
+                let name = child.child_by_field_name("name")
+                    .map(|n| resolve_param_name(&n, source))
+                    .unwrap_or_default();
+                let type_ann = child.child_by_field_name("type")
+                    .map(|n| node_text(&n, source));
+                ParameterDoc { name, type_annotation: type_ann, default_value: None }
+            }
+            "default_parameter" => {
+                let name = child.child_by_field_name("name")
+                    .map(|n| node_text(&n, source))
+                    .unwrap_or_default();
+                let default = child.child_by_field_name("value")
+                    .map(|n| node_text(&n, source));
+                ParameterDoc { name, type_annotation: None, default_value: default }
+            }
+            "typed_default_parameter" => {
+                let name = child.child_by_field_name("name")
+                    .map(|n| node_text(&n, source))
+                    .unwrap_or_default();
+                let type_ann = child.child_by_field_name("type")
+                    .map(|n| node_text(&n, source));
+                let default = child.child_by_field_name("value")
+                    .map(|n| node_text(&n, source));
+                ParameterDoc { name, type_annotation: type_ann, default_value: default }
+            }
+            "list_splat_pattern" | "dictionary_splat_pattern" => ParameterDoc {
+                name: resolve_param_name(&child, source),
+                type_annotation: None,
+                default_value: None,
+            },
+            _ => continue,
+        };
+        params.push(param);
+    }
+
+    params
+}
+
+fn resolve_param_name(node: &tree_sitter::Node, source: &[u8]) -> String {
+    match node.kind() {
+        "list_splat_pattern" => {
+            let inner = node.named_child(0)
+                .map(|n| node_text(&n, source))
+                .unwrap_or_default();
+            format!("*{inner}")
+        }
+        "dictionary_splat_pattern" => {
+            let inner = node.named_child(0)
+                .map(|n| node_text(&n, source))
+                .unwrap_or_default();
+            format!("**{inner}")
+        }
+        _ => node_text(node, source),
+    }
+}
+
+fn strip_python_quotes(s: &str) -> String {
+    let stripped = s.trim().trim_matches(|c: char| c == '"' || c == '\'');
+
+    let normalized = stripped.replace("\r\n", "\n");
+    let lines: Vec<&str> = normalized.lines().collect();
+
+    if lines.len() <= 1 {
+        return lines.first().map_or(String::new(), |l| l.trim().to_string());
+    }
+
+    let indent = lines.iter()
+        .skip(1)
+        .filter(|l| !l.trim().is_empty())
+        .map(|l| l.len() - l.trim_start().len())
+        .min()
+        .unwrap_or(0);
+
+    let mut result = lines[0].trim().to_string();
+    for line in &lines[1..] {
+        result.push('\n');
+        if !line.trim().is_empty() {
+            result.push_str(&line[indent..]);
+        }
+    }
+
+    result.trim().to_string()
+}
+
+fn node_text(node: &tree_sitter::Node, source: &[u8]) -> String {
+    node.utf8_text(source).unwrap_or("").to_string()
 }


### PR DESCRIPTION
Reworked the models and rewrote the Python parser to fix the data mapping issue. ClassDoc now has a methods field so methods actually land under their class instead of floating in the top-level functions array. FunctionDoc got parameters (with type annotations and default values) and return_type. ParsedFile has a language field now so frontend knows what it's looking at.

The Python parser no longer uses flat tree-sitter queries, it walks the AST directly which makes it easy to tell apart top-level functions from class methods. Decorated definitions (@staticmethod, @property etc.) are handled at both levels so they don't get silently dropped.