### PR TITLE
rename endpoints to follow REST conventions

### DIFF
--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -42,10 +42,10 @@ async fn main() {
     });
 
     let app = Router::new()
-        .route("/clone", post(clone_handler))
+        .route("/repos", post(clone_handler))
         .route("/repos", get(list_repos_handler))
         .route("/repos/:repo_name", delete(delete_repo_handler))
-        .route("/analyze/:repo_name", get(analyze_repo_handler))
+        .route("/repos/:repo_name/analysis", get(analyze_repo_handler))
         .layer(middleware::from_fn(auth::require_api_key))
         .with_state(config);
 


### PR DESCRIPTION
Renamed endpoints to follow REST conventions. POST /clone is now POST /repos since cloning is just creating a repo resource. GET /analyze/:repo_name is now GET /repos/:repo_name/analysis since it's a sub-resource of a repo. DELETE stayed the same, it was already correct. New code passes clippy pedantic.