### PR TITLE
add prefetch endpoint and branch selection for clone

### DIFF
--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -19,7 +19,7 @@ use std::path::PathBuf;
 use std::sync::Arc;
 use tokio::sync::Semaphore;
 use crate::models::AppConfig;
-use crate::repo_handlers::{clone_handler, list_repos_handler, analyze_repo_handler, delete_repo_handler};
+use crate::repo_handlers::{clone_handler, list_repos_handler, analyze_repo_handler, delete_repo_handler, prefetch_handler};
 use crate::user_handlers::{list_users_handler, get_user_handler, get_me_handler,patch_me_handler, patch_user_handler, create_user_handler, delete_user_handler};
 use crate::auth::{login_handler, logout_handler};
 
@@ -48,7 +48,7 @@ async fn main() {
         println!("  {key}");
         key
     });
-    
+
     let config = Arc::new(AppConfig {
         base_dir,
         clone_semaphore: Arc::new(Semaphore::new(max_clones)),
@@ -60,6 +60,7 @@ async fn main() {
         .route("/auth/login", post(login_handler));
 
     let protected_routes = Router::new()
+        .route("/repos/prefetch", post(prefetch_handler))
         .route("/repos", post(clone_handler))
         .route("/repos", get(list_repos_handler))
         .route("/repos/:repo_name", delete(delete_repo_handler))

--- a/backend/src/models.rs
+++ b/backend/src/models.rs
@@ -22,6 +22,8 @@ pub enum RepoStatus {
 pub struct RepoMeta {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub token: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub branch: Option<String>,
     #[serde(flatten)]
     pub status: RepoStatus,
 }
@@ -40,6 +42,20 @@ pub struct CloneRequest {
     pub name: String,
     pub token: Option<String>,
     pub depth: Option<i32>,
+    pub branch: Option<String>,
+}
+
+#[derive(Deserialize)]
+pub struct PrefetchRequest {
+    pub url: String,
+    pub token: Option<String>,
+}
+
+#[derive(Serialize)]
+pub struct PrefetchResponse {
+    pub default_branch: Option<String>,
+    pub branches: Vec<String>,
+    pub tags: Vec<String>,
 }
 
 #[derive(Serialize)]

--- a/backend/src/repo.rs
+++ b/backend/src/repo.rs
@@ -82,6 +82,7 @@ pub fn cleanup_stale_cloning(base_dir: &Path) {
 
                 let _ = save_meta(base_dir, repo_name, &RepoMeta {
                     token: meta.token,
+                    branch: meta.branch,
                     status: RepoStatus::CloneFailed {
                         error: "Clone interrupted by server shutdown".to_string(),
                     },
@@ -91,6 +92,7 @@ pub fn cleanup_stale_cloning(base_dir: &Path) {
             RepoStatus::Syncing { last_synced_at } => {
                 let _ = save_meta(base_dir, repo_name, &RepoMeta {
                     token: meta.token,
+                    branch: meta.branch,
                     status: RepoStatus::Ready { last_synced_at },
                 });
                 eprintln!("  Restored interrupted sync: {repo_name}");
@@ -98,6 +100,7 @@ pub fn cleanup_stale_cloning(base_dir: &Path) {
             RepoStatus::Ready { .. } | RepoStatus::SyncFailed { .. } if !dir_exists => {
                 let _ = save_meta(base_dir, repo_name, &RepoMeta {
                     token: meta.token,
+                    branch: meta.branch,
                     status: RepoStatus::CloneFailed {
                         error: "Repository directory is missing".to_string(),
                     },
@@ -165,7 +168,43 @@ pub fn list_repos(base_dir: &PathBuf) -> Result<Vec<RepoInfo>, AppError> {
     Ok(repos)
 }
 
-pub fn clone_repo(url: &str, target_path: &Path, token: Option<String>, depth: i32) -> Result<(), AppError> {
+pub fn prefetch_repo(url: &str, token: Option<String>) -> Result<crate::models::PrefetchResponse, AppError> {
+    let mut remote = git2::Remote::create_detached(url)?;
+
+    let mut callbacks = git2::RemoteCallbacks::new();
+    if let Some(token) = token {
+        callbacks.credentials(move |_url, _username, _allowed| {
+            git2::Cred::userpass_plaintext("x-access-token", &token)
+        });
+    }
+
+    remote.connect_auth(git2::Direction::Fetch, Some(callbacks), None)?;
+
+    let refs = remote.list()?;
+
+    let mut branches = Vec::new();
+    let mut tags = Vec::new();
+    let mut default_branch = None;
+
+    for head in refs {
+        let name = head.name();
+        if name == "HEAD" {
+            default_branch = head
+                .symref_target()
+                .and_then(|t| t.strip_prefix("refs/heads/"))
+                .map(str::to_owned);
+        } else if let Some(branch) = name.strip_prefix("refs/heads/") {
+            branches.push(branch.to_owned());
+        } else if let Some(tag) = name.strip_prefix("refs/tags/")
+            && !tag.ends_with("^{}") {
+            tags.push(tag.to_owned());
+        }
+    }
+
+    Ok(crate::models::PrefetchResponse { default_branch, branches, tags })
+}
+
+pub fn clone_repo(url: &str, target_path: &Path, token: Option<String>, depth: i32, branch: Option<&str>) -> Result<(), AppError> {
     let mut callbacks = git2::RemoteCallbacks::new();
 
     if let Some(token) = token {
@@ -180,6 +219,9 @@ pub fn clone_repo(url: &str, target_path: &Path, token: Option<String>, depth: i
 
     let mut builder = git2::build::RepoBuilder::new();
     builder.fetch_options(fetch_opts);
+    if let Some(branch) = branch {
+        builder.branch(branch);
+    }
     builder.clone(url, target_path)?;
 
     Ok(())

--- a/backend/src/repo_handlers.rs
+++ b/backend/src/repo_handlers.rs
@@ -8,9 +8,23 @@ use std::fs;
 use std::sync::Arc;
 use axum::extract::Path;
 
-use crate::models::{AppConfig, CloneRequest};
+use crate::models::{AppConfig, CloneRequest, PrefetchRequest};
 use crate::errors::AppError;
 use crate::repo;
+
+pub async fn prefetch_handler(
+    State(_config): State<Arc<AppConfig>>,
+    Json(payload): Json<PrefetchRequest>,
+) -> Result<impl IntoResponse, AppError> {
+    repo::validate_repo_url(&payload.url)?;
+
+    let url = payload.url;
+    let token = payload.token;
+
+    let response = tokio::task::spawn_blocking(move || repo::prefetch_repo(&url, token)).await??;
+
+    Ok(Json(response))
+}
 
 pub async fn list_repos_handler(
     State(config): State<Arc<AppConfig>>,
@@ -46,15 +60,18 @@ pub async fn clone_handler(
     let url = payload.url;
     let token = payload.token;
     let depth = payload.depth.unwrap_or(1);
+    let branch = payload.branch;
     let base_dir = config.base_dir.clone();
 
     let base_dir_pre = config.base_dir.clone();
     let name_pre = name.clone();
     let token_pre = token.clone();
+    let branch_pre = branch.clone();
 
     tokio::task::spawn_blocking(move || {
         repo::save_meta(&base_dir_pre, &name_pre, &crate::models::RepoMeta {
             token: token_pre,
+            branch: branch_pre,
             status: crate::models::RepoStatus::Cloning,
         })
     })
@@ -63,10 +80,11 @@ pub async fn clone_handler(
     tokio::task::spawn_blocking(move || {
         let _permit = permit;
 
-        match repo::clone_repo(&url, &target_path, token.clone(), depth) {
+        match repo::clone_repo(&url, &target_path, token.clone(), depth, branch.as_deref()) {
             Ok(()) => {
                 let _ = repo::save_meta(&base_dir, &name, &crate::models::RepoMeta {
                     token,
+                    branch,
                     status: crate::models::RepoStatus::Ready {
                         last_synced_at: chrono::Utc::now(),
                     },
@@ -75,6 +93,7 @@ pub async fn clone_handler(
             Err(e) => {
                 let _ = repo::save_meta(&base_dir, &name, &crate::models::RepoMeta {
                     token,
+                    branch,
                     status: crate::models::RepoStatus::CloneFailed {
                         error: e.to_string(),
                     },

--- a/backend/src/sync.rs
+++ b/backend/src/sync.rs
@@ -43,6 +43,9 @@ fn sync_all_repos(base_dir: &Path) {
 
         let Some(meta) = crate::repo::load_meta(base_dir, name) else { continue };
 
+        let token = meta.token;
+        let branch = meta.branch;
+
         let (crate::models::RepoStatus::Ready { last_synced_at }
         | crate::models::RepoStatus::SyncFailed { last_synced_at, .. }) = meta.status
         else {
@@ -50,15 +53,17 @@ fn sync_all_repos(base_dir: &Path) {
         };
 
         let _ = crate::repo::save_meta(base_dir, name, &crate::models::RepoMeta {
-            token: meta.token,
+            token,
+            branch: branch.clone(),
             status: crate::models::RepoStatus::Syncing { last_synced_at },
         });
 
-        match pull_repo(base_dir, &path) {
+        match pull_repo(base_dir, &path, branch.as_deref()) {
             Ok(()) => {
                 if let Some(meta) = crate::repo::load_meta(base_dir, name) {
                     let _ = crate::repo::save_meta(base_dir, name, &crate::models::RepoMeta {
                         token: meta.token,
+                        branch: meta.branch,
                         status: crate::models::RepoStatus::Ready {
                             last_synced_at: chrono::Utc::now(),
                         },
@@ -70,6 +75,7 @@ fn sync_all_repos(base_dir: &Path) {
                 if let Some(meta) = crate::repo::load_meta(base_dir, name) {
                     let _ = crate::repo::save_meta(base_dir, name, &crate::models::RepoMeta {
                         token: meta.token,
+                        branch: meta.branch,
                         status: crate::models::RepoStatus::SyncFailed {
                             last_synced_at,
                             error: e.clone(),
@@ -83,7 +89,7 @@ fn sync_all_repos(base_dir: &Path) {
     }
 }
 
-fn pull_repo(base_dir: &Path, path: &Path) -> Result<(), String> {
+fn pull_repo(base_dir: &Path, path: &Path, branch: Option<&str>) -> Result<(), String> {
     let repo = git2::Repository::open(path)
         .map_err(|e| e.to_string())?;
 
@@ -107,7 +113,12 @@ fn pull_repo(base_dir: &Path, path: &Path) -> Result<(), String> {
     }
 
     fetch_opts.remote_callbacks(callbacks);
-    remote.fetch(&["refs/heads/*:refs/remotes/origin/*"], Some(&mut fetch_opts), None)
+
+    let refspec = match branch {
+        Some(b) => format!("refs/heads/{b}:refs/remotes/origin/{b}"),
+        None => "refs/heads/*:refs/remotes/origin/*".to_string(),
+    };
+    remote.fetch(&[&refspec], Some(&mut fetch_opts), None)
         .map_err(|e| e.to_string())?;
 
     let fetch_head = repo.find_reference("FETCH_HEAD")


### PR DESCRIPTION
Adds POST /repos/prefetch to probe a remote URL and return available branches, tags and default branch before cloning. Extends POST /repos with an optional branch field (defaults to remote HEAD). Branch is stored in meta and used by the sync task for targeted fetching. Passes clippy pedantic. 
Closes #41 